### PR TITLE
_setClassCounter undefined index #16

### DIFF
--- a/src/Base/Register.php
+++ b/src/Base/Register.php
@@ -252,6 +252,10 @@ class Register
      */
     protected static function _setClassCounter($class)
     {
+        if (!isset(self::$_classCounter[$class])) {
+            self::$_classCounter[$class] = 0;
+        }
+
         self::$_classCounter[$class] += 1;
     }
 


### PR DESCRIPTION
fixed error with unfined index when register add to counter library at first time

Modified: /Base/Register.php
          -- Modified --
             _setClassCounter check that class counter array index exists
