### PR TITLE
unserialize BlueObject (issue #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.1.2 - 2014-10-10
+
+### Fixed
+* unserialize BlueObject [issue #22](https://github.com/chajr/class-kernel/issues/22)
+
 ## 0.1.1 - 2014-10-06
 
 ### Fixed

--- a/src/Base/BlueObject.php
+++ b/src/Base/BlueObject.php
@@ -945,7 +945,7 @@ trait BlueObject
         if (is_object($data)) {
             $this->_DATA[get_class($data)] = $data;
         } else {
-            $this->_DATA = unserialize($data);
+            $this->_DATA = $data;
         }
 
         return $this;


### PR DESCRIPTION
This version introduces multiple enhancements:

fixed error with double unserialize data
## Details of additions/deletions below:

Modified:   Base/BlueObject.php
            -- Updated --
                _appendSerialized removed duplicated `unserialize` function

Modified:   CHANGELOG.md
            -- Added --
                changelog information
