### PR TITLE
set data with check (issue #11)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Class Kernel libraries",
     "keywords": ["register", "xml", "object container", "class kernel"],
     "homepage": "https://github.com/chajr/class-kernel",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "authors": [
         {
             "name": "Michał Adamiak",

--- a/examples/base_object/set_data.php
+++ b/examples/base_object/set_data.php
@@ -116,6 +116,18 @@ $objectXml = new ClassKernel\Data\Object([
 ]);
 ?>
 
+<h5>Change existing key with the same data</h5>
+<code>
+<pre>$objectArray->setFirstData('a');
+var_dump($objectArray->dataChanged());</pre>
+</code>
+<?php
+$objectArray->setFirstData('a');
+echo '<pre>';
+var_dump($objectArray->dataChanged());
+echo '</pre>';
+?>
+
 <h5>Created objects dump</h5>
 <?php
 echo '<pre>';


### PR DESCRIPTION
This version introduces multiple enhancements:

added changes from missing issue
change data only that data for given key was not set or data is different
also changed === null to is_null()
## Details of additions/deletions below:

Modified:   Base/BlueObject.php
            -- Added --
                _changeData moved part of logic form _putData method (set data in object)
            -- Updated --
                _putData part of logic moved to _changeData also added checking that data is different that set in gicen key
                getData changed === null to is_null()
                hasData refactor changes
                compareData changed === null to is_null()
                unsetData changed === null to is_null()
                restoreData changed === null to is_null()

Modified:   examples/base_object/set_data.php
            -- Added --
                example of try to change data with the same value

Modified:   composer.json
            -- Updated --
                changed version from 0.2.1 to 0.2.2
