### PR TITLE
array_key_exist in _arrayToXml error [0.2.6] (issue #44)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Class Kernel libraries",
     "keywords": ["register", "xml", "object container", "class kernel"],
     "homepage": "https://github.com/chajr/class-kernel",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "authors": [
         {
             "name": "Michał Adamiak",

--- a/src/Base/BlueObject.php
+++ b/src/Base/BlueObject.php
@@ -1197,12 +1197,14 @@ trait BlueObject
             }
 
             try {
-                if (array_key_exists('@attributes', $value)) {
+                $isArray = is_array($value);
+
+                if ($isArray && array_key_exists('@attributes', $value)) {
                     $attributes = $value['@attributes'];
                     unset ($value['@attributes']);
                 }
 
-                if (is_array($value)) {
+                if ($isArray) {
                     $parent = $this->_convertArrayDataToXml(
                         $value,
                         $addCdata,


### PR DESCRIPTION
This version introduces multiple enhancements:

fixed conversion array to xml with attributes
changed version in composer
## Details of additions/deletions below:

Modified:   Base/BlueObject.php
            -- Updated --
                _arrayToXml check that $value is array before array_key_exists execution

Modified:   composer.json
            -- Modified --
                changed version from 0.2.5 to 0.2.6
