### PR TITLE
DataReturn callback error on getData [0.2.7] (issue #46)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Class Kernel libraries",
     "keywords": ["register", "xml", "object container", "class kernel"],
     "homepage": "https://github.com/chajr/class-kernel",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "authors": [
         {
             "name": "Michał Adamiak",


### PR DESCRIPTION
This version introduces multiple enhancements:

fixed error when try to prepare whole data on return
also fixed some export methods to handle data preparation
## Details of additions/deletions below:

Modified:   src/Base/BlueObject.php
            -- Added --
                _prepareWholeData allow to use return preparation on all data in object
            -- Updated --
                _dataPreparation code refactor, fixed problem with null key and usage of _prepareWholeData method
                toXml use method getData instead of _DATA array
                toStdClass use method getData instead of _DATA array

Modified:   composer.json
            -- Modified --
                changed version from 0.2.6 to 0.2.7
