### PR TITLE
Data preparation in __constructor (issue #48)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Class Kernel libraries",
     "keywords": ["register", "xml", "object container", "class kernel"],
     "homepage": "https://github.com/chajr/class-kernel",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "authors": [
         {
             "name": "Michał Adamiak",


### PR DESCRIPTION
This version introduces multiple enhancements:

allow to launch data preparation in constructor
applied for XML, JSON, stdClass, serialized and array
also some documentation update
## Details of additions/deletions below:

Modified:   Base/BlueObject.php
            -- Updated --
                __call documntation update
                returnOriginalData documntation update
                compareData documntation update
                _appendJson apply data by setData method
                _appendSimpleXml apply data by setData method
                _appendXml apply data by setData method
                _appendArray apply data by setData method
                _appendStdClass apply data by setData method
                _appendSerialized apply data by setData method

Modified:   composer.json
            -- Modified --
                changed version from 0.2.7 to 0.2.8
